### PR TITLE
[release/6.0] add CMake build script for the release/6.0 branch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,34 @@
+
+cmake_minimum_required(VERSION 3.12.3)
+
+project(SQLite
+  LANGUAGES C)
+
+set(CMAKE_POSITION_INDEPENDENT_CODE YES)
+
+add_library(SQLite3
+  Sources/CSQLite/sqlite3.c)
+if(CMAKE_SYSTEM_NAME STREQUAL Windows AND BUILD_SHARED_LIBS)
+  target_compile_definitions(SQLite3 PRIVATE
+    "SQLITE_API=__declspec(dllexport)")
+endif()
+target_include_directories(SQLite3 PUBLIC
+  Sources/CSQLite/include)
+
+add_executable(sqlite
+  Sources/sqlite/shell.c)
+target_compile_definitions(sqlite PRIVATE
+  SQLITE_OMIT_LOAD_EXTENSION)
+target_link_libraries(sqlite PRIVATE
+  SQLite3)
+
+install(TARGETS SQLite3
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin)
+install(FILES
+    Sources/CSQLite/include/sqlite3.h
+    Sources/CSQLite/include/sqlite3ext.h
+  DESTINATION
+    include)
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,12 @@ cmake_minimum_required(VERSION 3.12.3)
 project(SQLite
   LANGUAGES C)
 
+# Generate PIC for ELF/MachO targets.
 set(CMAKE_POSITION_INDEPENDENT_CODE YES)
+
+# Use hidden visibility for ELF/MachO targets.
+set(CMAKE_C_VISIBILITY_PRESET hidden)
+set(CMAKE_VISIBILITY_INLINES_HIDDEN YES)
 
 add_library(SQLite3
   Sources/CSQLite/sqlite3.c)


### PR DESCRIPTION
This PR cherry-picks the CMake build changes needed to build swift-toolchain-sqlite with CMake, in the release/6.0 branch.
They are needed to build the browsercompany's release/6.0 toolchain.