### PR TITLE
CSQLite: add `module.modulemap`

### DIFF
--- a/Sources/CSQLite/include/module.modulemap
+++ b/Sources/CSQLite/include/module.modulemap
@@ -1,0 +1,5 @@
+
+module SwiftToolchainCSQLite {
+  header "sqlite3.h"
+  header "sqlite3ext.h"
+}


### PR DESCRIPTION
Add a modulemap for this module to allow SPM to build only the tests against the CMake generated products which are distributed as part of the toolchain image.