### PR TITLE
Add support to conditionally enable FTS5

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,11 @@
 // swift-tools-version: 6.0
 import PackageDescription
+import Foundation
+
+var toolchainCSettings: [CSetting] = []
+if ProcessInfo.processInfo.environment["SQLITE_ENABLE_FTS5"] == "1" {
+    toolchainCSettings.append(.define("SQLITE_ENABLE_FTS5"))
+}
 
 let package = Package(
   name: "swift-toolchain-sqlite",
@@ -37,6 +43,7 @@ let package = Package(
       name: "SwiftToolchainCSQLite",
       path: "Sources/CSQLite",
       publicHeadersPath: "include",
+      cSettings: toolchainCSettings,
       linkerSettings: [
         // Needed for swift_addNewDSOImage
         .linkedLibrary("swiftCore", .when(platforms: [.windows, .wasi]))

--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ It is not intended as a general-purpose SQLite package, nor does it aim to provi
 This build of this package has been validated for macOS, iOS, tvOS, watchOS, visionOS, Mac Catalyst, Linux, Android, Windows, WebAssembly, and FreeBSD.
 On most platforms, the Swift toolchain uses a copy of SQLite provided by the platform SDK or package manager instead of this package.
 
+### Compile-time Options
+
+Set the following environment variables to enable the corresponding compile-time options.
+
+- `SQLITE_ENABLE_FTS5=1` to enable [FTS5](https://www.sqlite.org/fts5.html)
 
 Contributing to /swift-toolchain-sqlite
 -------------


### PR DESCRIPTION
The following PR adds support for setting `SQLITE_ENABLE_FTS5=1` as an environment variable when compiling `SwiftToolchainCSQLite` to enable [FTS5](https://www.sqlite.org/fts5.html).

This is the best way I thought to enable this feature when `swift-toolchain-sqlite` is not directly used as a dependency (e.g. when using https://github.com/stephencelis/SQLite.swift).

Also, when working on this I think the defines that are used currently are in the wrong location. They are defined as part of the `sqlite` executable, but they should be in the `cSettings` of `SwiftToolchainCSQLite`. For example `SQLITE_OMIT_LOAD_EXTENSION` is not taken into account when compiling `sqlite3.c`.