### PR TITLE
Use `Invoke-Program` for the Windows build command

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -11,7 +11,7 @@ jobs:
     with:
       linux_build_command: "swift build"
       linux_exclude_swift_versions: '[{"swift_version": "5.8"}, {"swift_version": "5.9"}, {"swift_version": "5.10"}]'
-      windows_build_command: "swift build"
+      windows_build_command: "Invoke-Program swift build"
       windows_exclude_swift_versions: '[{"swift_version": "5.9"}]'
       macos_build_command: "xcrun swift build"
       macos_exclude_xcode_versions: '[{"xcode_version": "16.0"}, {"xcode_version": "16.1"}]'


### PR DESCRIPTION
Windows does not stop scripts when native commands exit with non-zero. Instead, their exit status has to be checked manually. This can be done through an `Invoke-Program` function that is added to the script running `windows_build_command`, which also previously prefixed the given command. This is changing in
https://github.com/swiftlang/github-workflows/pull/154 since it doesn't help with multi-line commands - update our modified `windows_build_command` to use `Invoke-Program` instead.